### PR TITLE
Fixed a small bug to use correct endpoints of path segments

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -161,15 +161,18 @@ function extractPointsFromPath(params)
 			src = mpts[k];
 		end
 	end
-	
+		
 	-- Adding the points for curve, Making relative points constant
+	local count = 0
 	for k,v in pairs(cpts) do 
 	 	if (src) then
 			-- src = v;
-			
+			count = count+1
 			cpts[k] = {x=src.x+v.x,y=src.y+v.y};
 			table.insert(finalPts, cpts[k]);
-			src = cpts[k];
+			if (count % 3 == 0) then
+				src = cpts[k];
+			end
 		end
 	end
 	


### PR DESCRIPTION
This new code works the way SVG path actually works, ever third point is the end point of one curve and the beginning point of the next curve. This change counts to every third points so it can be used for both curves. I don't think I'm explaining it well, so try it out and see.
